### PR TITLE
GitLab Job generation module

### DIFF
--- a/data/gitlab/generator/template.py
+++ b/data/gitlab/generator/template.py
@@ -1,0 +1,56 @@
+import re
+class GeneratorTemplate:
+    gitlabjobtemplate = r"""
+    {user-provided or "scratch"}:
+      image: {user provided or "scratch"}
+      script:
+    {Commands given by the user. If unspecified, "echo 'Hello'"}
+      variables:
+        KUBERNETES_CPU_REQUEST: {provided}
+        KUBERNETES_CPU_LIMIT: {provided}
+        KUBERNETES_MEMORY_REQUEST: {provided}
+        KUBERNETES_MEMORY_LIMIT: {provided}
+"""
+    instruction_template = (
+    "Using the following additional context and GitLab job YAML syntax:\n\n"
+    "Additional Context:\n{additional_context}\n\n"
+    "Syntax:\n{gitlabjobtemplate}\n\n"
+    "Generate a GitLab job based on the template :\n\n"
+    "Question: {question}\n"
+    "Answer:"
+)
+    # Function to fill missing values in the question
+    # Default values
+    DEFAULT_VALUES = {
+        "KUBERNETES_CPU_REQUEST": "0.5",
+        "KUBERNETES_CPU_LIMIT": "1",
+        "KUBERNETES_MEMORY_REQUEST": "512Mi",
+        "KUBERNETES_MEMORY_LIMIT": "1Gi"
+    }
+    def fill_missing_question_values(self,question: str) -> str:
+        lower_question = question.lower()
+
+        assumptions = []
+
+        if not re.search(r"cpu request|cpu requests|requires cpus|", lower_question):
+            assumptions.append(f"Assuming {self.DEFAULT_VALUES['KUBERNETES_CPU_REQUEST']} KUBERNETES_CPU_REQUEST")
+        if not re.search(r"max cpu|cpu max|cpu limit", lower_question):
+            assumptions.append(f"Assuming {self.DEFAULT_VALUES['KUBERNETES_CPU_LIMIT']} KUBERNETES_CPU_LIMIT")
+        if not re.search(r"memory request|RAM request|requires RAM", lower_question):
+            assumptions.append(f"Assuming {self.DEFAULT_VALUES['KUBERNETES_MEMORY_REQUEST']} KUBERNETES_MEMORY_REQUEST")
+        if not re.search(r"max RAM|max memory|maximum memory", lower_question):
+            assumptions.append(f"Assuming {self.DEFAULT_VALUES['KUBERNETES_MEMORY_LIMIT']} KUBERNETES_MEMORY_LIMIT")
+
+        if assumptions:
+            question += " " + " ".join(assumptions)
+        
+        return question
+    # Todo
+    additional_context = """
+"""
+    def getGeneratorTemplate(self):
+        return self.gitlabjobtemplate
+    def getInstructionTemplate(self):
+        return self.instruction_template
+    def getAdditionalContext(self):
+        return self.getAdditionalContext

--- a/data/scheduler/release_frequency.py
+++ b/data/scheduler/release_frequency.py
@@ -23,9 +23,7 @@ class ReleaseFrequency:
         "Answer:"
     )
     additional_context = """
-The table above details stable release data from several open-source repositories.
-It serves as a reference to understand how code changes, bug reports, and contributor counts
-influence the release frequency. This context helps in assessing the optimal release frequency.
+   If the question asks about healthcare, military or government code, provide a higher number of days for stability and compliance testing.
 """
     def getInstructionTemplate(self):
         return self.instruction_template

--- a/env/env.py
+++ b/env/env.py
@@ -1,2 +1,3 @@
 class Env:
-    API_URL = "https://api-inference.huggingface.co/models/tiiuae/falcon-7b-instruct"
+    Falcon_API_URL = "https://api-inference.huggingface.co/models/tiiuae/falcon-7b-instruct"
+    StarCoder_API_URL = "https://api-inference.huggingface.co/models/bigcode/starcoder"

--- a/release-scheduler/core.py
+++ b/release-scheduler/core.py
@@ -1,13 +1,14 @@
 import sys
 
 sys.path.append("./")
-from auth import authenticator
-import datetime
-import release_scheduler.scheduler
 from release_scheduler.scheduler import Scheduler
+from gitlabjob_generator.generator import Generator
 
 if __name__ == "__main__":
-    choice=input("1: Generate a ProwJob\n2: Debug a ProwJob\n3: Get product release suggestions ")
+    choice=input("1: Generate a GitLabJob\n2: Debug a GitLabJob\n3: Get product release suggestions ")
     if choice == "1":
+        generator_instance = Generator()
+        generator_instance.GenerateJob()
+    elif choice == "3":
         scheduler_instance = Scheduler()
         scheduler_instance.GetSchedule()

--- a/release-scheduler/gitlabjob_generator/generator.py
+++ b/release-scheduler/gitlabjob_generator/generator.py
@@ -2,28 +2,29 @@ import sys
 
 sys.path.append("./")
 from auth import authenticator
-from data.scheduler import release_frequency
+from data.gitlab.generator.template import GeneratorTemplate
 from env.env import Env
 import requests
 
-class Scheduler:
+class Generator:
     def query_model(self, prompt: str, headers):
         payload = {"inputs": prompt, "parameters": {"max_new_tokens": 200, "temperature": 0.2}}
         env = Env()
-        response = requests.post(env.Falcon_API_URL, headers=headers, json=payload)
+        response = requests.post(env.StarCoder_API_URL, headers=headers, json=payload)
         return response.json()
-    def GetSchedule(self):
+    def GenerateJob(self):
         authenticator_instance = authenticator.Authenticator()
         auth_header = authenticator_instance.getAuthenticationHeader()
         headers = {}
         headers.update(auth_header)
-        scheduler_instance = release_frequency.ReleaseFrequency()
-        frequency_table = scheduler_instance.getFrequencyTable()
-        instruction_template = scheduler_instance.getInstructionTemplate()
-        question = input("Enter your question about optimal release frequency: ")
+        generator_instance = GeneratorTemplate()
+        job = generator_instance.getGeneratorTemplate()
+        instruction_template = generator_instance.getInstructionTemplate()
+        question = input("Enter details of the GitLab job: ")
+        question = generator_instance.fill_missing_question_values(question)
         prompt = instruction_template.format(
-            additional_context=scheduler_instance.getAdditionalContext(),
-            table=frequency_table,
+            additional_context=generator_instance.getAdditionalContext(),
+            gitlabjobtemplate=job,
             question=question
         )
         result = self.query_model(prompt,headers)


### PR DESCRIPTION
Generate a simple GitLab job that can be used to run a script. There are certain assumed values for CPU and memory requests. Based on your existing infrastructure, data about your resources can be provided as context. For example, if you specify a certain memory limit (which represents the max limit of memory your cluster has), the generated job will use that as max memory.